### PR TITLE
Skip excessive lags in feature matrix generation

### DIFF
--- a/stock_predictor/data.py
+++ b/stock_predictor/data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import warnings
 from datetime import date, datetime
 from pathlib import Path
 from typing import Iterable, List, Sequence, Tuple
@@ -98,9 +99,17 @@ def build_feature_matrix(
     feature_columns: List[List[float]] = []
 
     lags_sorted = sorted(set(int(lag) for lag in lags))
+    max_valid_lag = max(len(closes) - forecast_horizon - 1, 0)
     for lag in lags_sorted:
         if lag <= 0:
             raise ValueError("ラグは正の整数で指定してください")
+        if lag > max_valid_lag:
+            warnings.warn(
+                f"利用可能な履歴({max_valid_lag})を超えるラグ {lag} はスキップします",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            continue
         shifted_close = [float("nan")] * lag + closes[:-lag]
         feature_columns.append(shifted_close)
         feature_names.append(f"lag_{lag}_close")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -35,6 +35,19 @@ def test_build_feature_matrix_creates_lag_and_returns_targets(sample_prices):
     assert len(X[0]) == len(feature_names)
 
 
+def test_build_feature_matrix_skips_too_long_lags(sample_prices):
+    short_prices = sample_prices[:8]
+
+    X, y, feature_names = build_feature_matrix(
+        short_prices, forecast_horizon=1, lags=(1, 2, 10)
+    )
+
+    assert len(X) > 0
+    assert len(X) == len(y)
+    assert "lag_10_close" not in feature_names
+    assert "lag_10_return" not in feature_names
+
+
 @pytest.fixture
 def sample_prices():
     return [

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -69,3 +69,13 @@ def test_ridge_regularization_does_not_shrink_bias():
 
     assert pytest.approx(2.0, rel=1e-6) == coefficients[0]
     assert all(abs(coef) < 1e-9 for coef in coefficients[1:])
+
+
+def test_train_and_evaluate_ignores_excessive_lags():
+    prices = generate_prices(days=8)
+
+    result = train_and_evaluate(prices, forecast_horizon=1, lags=(1, 2, 10), cv_splits=2)
+
+    assert result["model"].feature_names
+    assert "lag_10_close" not in result["model"].feature_names
+    assert "lag_10_return" not in result["model"].feature_names


### PR DESCRIPTION
## Summary
- skip lag features that exceed the available history to avoid NaN-only columns
- add regression tests confirming feature matrix construction and training tolerate excessive lags

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e64ef690e48321833c83ddf29c76a6