### PR TITLE
Fix CV splits to cover remainder and test tail signals

### DIFF
--- a/stock_predictor/model.py
+++ b/stock_predictor/model.py
@@ -82,13 +82,25 @@ def _root_mean_squared_error(y_true: Sequence[float], y_pred: Sequence[float]) -
     return math.sqrt(sum((a - b) ** 2 for a, b in zip(y_true, y_pred)) / len(y_true))
 
 def _time_series_splits(n_samples: int, n_splits: int):
-    fold_size = n_samples // (n_splits + 1)
+    if n_splits < 1:
+        return
+
+    base_fold_size = n_samples // (n_splits + 1)
+    remainder = n_samples - base_fold_size * (n_splits + 1)
+
     for i in range(1, n_splits + 1):
-        test_end = fold_size * i
-        train_indices = list(range(test_end))
-        test_indices = list(range(test_end, min(test_end + fold_size, n_samples)))
-        if not test_indices:
+        test_start = base_fold_size * i
+        test_size = base_fold_size
+        if i == n_splits:
+            test_size += remainder
+        test_end = min(test_start + test_size, n_samples)
+
+        train_indices = list(range(test_start))
+        test_indices = list(range(test_start, test_end))
+
+        if not train_indices or not test_indices:
             continue
+
         yield train_indices, test_indices
 
 def train_and_evaluate(

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 import pytest
 
 from stock_predictor.backtest import simulate_trading_strategy
+from stock_predictor.data import build_feature_dataset
 
 
 def generate_prices(start_price: float = 100.0, days: int = 12, step: float = 1.0):
@@ -73,3 +74,30 @@ def test_simulate_trading_strategy_provides_trade_timing():
     assert isinstance(exit_, datetime)
     assert exit_ > entry
     assert (exit_ - entry).days == 2
+
+
+def test_simulate_trading_strategy_generates_tail_signals():
+    prices = generate_prices(days=16)
+
+    dataset = build_feature_dataset(
+        prices,
+        forecast_horizon=1,
+        lags=(1,),
+        rolling_windows=(3, 5),
+    )
+
+    result = simulate_trading_strategy(
+        prices,
+        forecast_horizon=1,
+        lags=(1,),
+        rolling_windows=(3, 5),
+        cv_splits=3,
+        threshold=0.0,
+    )
+
+    assert result["signals"], "シグナルが生成されていること"
+
+    last_signal_date = result["signals"][-1]["date"]
+    expected_last_date = prices[dataset.sample_indices[-1]]["Date"]
+
+    assert last_signal_date == expected_last_date


### PR DESCRIPTION
## Summary
- adjust the time-series split helper so the final fold absorbs any remainder samples
- ensure backtest predictions cover the tail by adding a regression test for signal generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e65d0dde20832187cc887a5943602c