### PR TITLE
Add position-aware backtesting metrics

### DIFF
--- a/stock_predictor/cli.py
+++ b/stock_predictor/cli.py
@@ -162,14 +162,21 @@ def backtest(
     click.echo(f"使用ラグ: {', '.join(str(l) for l in effective_lags)}")
     click.echo(f"トレード回数: {result['trades']}")
     click.echo(f"勝率: {result['win_rate'] * 100:.2f}%")
-    click.echo(f"累積リターン: {result['cumulative_return'] * 100:.2f}%")
+    click.echo(f"累積損益: {result['cumulative_return']:.2f}")
 
     preview = result["signals"][:10]
     if preview:
-        click.echo("--- シグナル一覧(最大10件) ---")
-        for signal in preview:
-            date = signal["date"]
+        click.echo("--- トレード一覧(最大10件) ---")
+        for trade in preview:
+            entry = trade["entry"]
+            exit_ = trade["exit"]
+            entry_time = entry["timestamp"]
+            exit_time = exit_["timestamp"]
+            predicted = entry.get("predicted_return", 0.0) * 100
+            realized = trade.get("return", 0.0) * 100
+            profit = trade.get("profit", 0.0)
             click.echo(
-                f"{date}: {signal['action']} | 予測リターン {signal['predicted_return'] * 100:.2f}%"
-                f" / 実現リターン {signal['actual_return'] * 100:.2f}%"
+                f"{entry_time.date()} -> {exit_time.date()}: {trade['direction']}"
+                f" | 予測 {predicted:.2f}% / 実現 {realized:.2f}%"
+                f" | 損益 {profit:.2f}"
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,7 +86,7 @@ def test_cli_backtest_outputs_strategy_metrics(tmp_path):
 
     assert result.exit_code == 0
     assert "トレード回数" in result.output
-    assert "累積リターン" in result.output
+    assert "累積損益" in result.output
 
 
 def test_cli_fetches_data_from_yfinance(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary
- expand backtest tests to cover trade lifecycle, position limits, and new signal schema
- implement explicit position tracking with realized PnL aggregation in the backtest engine
- adjust CLI output to the new trade result format and cumulative profit reporting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e660bb26888321bebe418e7a8512e3